### PR TITLE
Review process document

### DIFF
--- a/docs/review-checklist.md
+++ b/docs/review-checklist.md
@@ -29,7 +29,7 @@ The test is automatable as either [reftest][reftest] or a
 test must be manual. 
 
 
-## Reftests
+## Reftests Only
 <input type="checkbox">
  The test has a [self-describing][selftest] statement 
 

--- a/docs/review-checklist.md
+++ b/docs/review-checklist.md
@@ -1,0 +1,66 @@
+---
+layout: default
+title: Test Review Checklist
+---
+
+# Review Checklist
+
+When reviewing a test, make sure the test follows the 
+[format][format] and [style][style] guidelines.
+
+In addition, the test should be checked for the following:
+
+## All tests
+<input type="checkbox"> 
+The test passes when it's supposed to pass
+
+<input type="checkbox"> 
+The test fails when it's supposed to fail
+
+<input type="checkbox"> 
+The test is testing what it thinks it's testing
+
+<input type="checkbox"> 
+The spec backs up the expected behavior in the test. 
+
+<input type="checkbox"> 
+The test is automatable as either [reftest][reftest] or a 
+[script test][scripttest] unless there's a very good reason why the 
+test must be manual. 
+
+
+## Reftests
+<input type="checkbox">
+ The test has a [self-describing][selftest] statement 
+
+<input type="checkbox"> 
+The self-describing statement is accurate, precise, simple, and 
+self-explanatory. Your mother/husband/roommate/brother/bus driver 
+should be able to say whether the test passed or failed within a few 
+seconds, and not need to spend several minutes thinking or asking 
+questions.
+
+<input type="checkbox"> 
+The reference file is accurate and will render pixel-perfect 
+identically to the test on all platforms.
+
+<input type="checkbox"> 
+The reference file uses a different technique that won't fail in 
+the same way as the test.
+
+<input type="checkbox"> 
+The title is descriptive but not too wordy.
+
+<input type="checkbox"> 
+The test is as cross-platform as reasonably possible, working 
+across different devices, screen resolutions, paper sizes, etc. If 
+there are limitations (e.g. the test will only work on 96dpi 
+devices, or screens wider than 200 pixels) that these are documented 
+in the instructions.
+
+
+[format]: ./test-format-guidelines.html
+[style]: ./test-style-guidelines.html
+[reftest]: ./reftests.html
+[scripttest]: ./testharness-documentation.html
+[selftest]: ./test-style-guidelines.html#self-describing

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -49,7 +49,7 @@ merged into the repository. The merge may be done by the spec's Test
 Facilitator or someone that is overseeing the test repository.
 * The merged tests are considered Approved.
 
-# Test Review and Approve Process in Shepherd (CSS tests only)
+# Test Review and Approval Process in Shepherd (CSS tests only)
 
 If you're writing CSS tests, you may follow an alternative process
 using [Shepherd][shepherd] defined on the 

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -3,25 +3,65 @@ layout: default
 title: Test Review and Approval Process
 ---
 
-# Test Review and Approval Process
+<a name="review-policy">
 
-The general workflow for test reviews and approval follows the GitHub
+# Test Review Policy
+
+In order to encourage a high level of quality in the W3C test
+suites, test contributions must be reviewed by a peer.
+
+Reviewers may be:
+
+- Spec editors
+- The test coordinator for that spec
+- An implementor
+- Anyone with the ability to read and understand the spec along
+with an understanding of the [format][format] and [style][style] guidelines 
+
+**The reviewer can be a colleague of the contributor as long as the**
+**proceedings are public.**
+
+**A reviewer cannot review his/her own tests and changes.**
+
+*To assist with test reviews, a [review checklist][review-checklist]*
+*is available.*
+
+<a name="github-process">
+
+# Test Review and Approval Process on Github
+
+The preferred method for reviewing tests is on Github. The general 
+workflow for test reviews and approval follows the GitHub
 contribution model and is summarized here: 
 
-* Pre-condition: we assume everyone that is interested in reviewing and/or
-approving W3C's tests will set a "Watch" at GitHub so they will be notified
-when a Pull Request (PR) is made. 
-* To initiate a review, make a Pull Request to the main `web-platform-
-tests/master` on GitHub. This will notify all subscribers of the PR. The
-review initiator can also notify the group of the PR via the mailing list in
-our [communication channels][1]. 
-* Reviewers should review the test code and reply accordingly. If no issues
-are found, the reviewer should state that so there is a trail a review was
-done. 
-* After all of the review issues are addressed, the PR will be merged into
-the repository. The merge may be done by the spec's Test Facilitator or
-someone that is overseeing the test repository.
-* The merged tests are considered Approved. 
+* Pre-condition: Those interested in reviewing and/or approving
+W3C's tests will set a "Watch" at GitHub so they will be notified 
+when a Pull Request (PR) is made.
+* To initiate a review, make a Pull Request to the main 
+```web-platform-tests/master``` or ```csswg-test/master``` on 
+GitHub. This will notify all subscribers of the PR, including 
+the test coordinator and test reviewers.
+* Reviewers should review the test code and reply accordingly in 
+Github. If no issues are found, the reviewer should state that so 
+there is a trail a review was done. 
+* After all of the review issues are addressed, the PR will be 
+merged into the repository. The merge may be done by the spec's Test 
+Facilitator or someone that is overseeing the test repository.
+* The merged tests are considered Approved.
 
-[1]: /communication-channels.html
+# Test Review and Approve Process in Shepherd (CSS tests only)
 
+If you're writing CSS tests, you may follow an alternative process
+using [Shepherd][shepherd] defined on the 
+[CSSWG wiki][csswg-wiki-review]. This process will continue to be 
+supported and will soon be more integrated with the Github workflow 
+(Target date: Q1 2014). Note that if CSS tests are submitted through
+Github following the process above, they will ultimately appear in 
+Shepherd when the the PR is merged.
+
+
+[format]: ./test-format-guidelines.html
+[style]: ./test-style-guidelines.html
+[review-checklist]: ./review-checklist.html
+[shepherd]: http://test.csswg.org/shepherd
+[csswg-wiki-review]: http://wiki.csswg.org/test/review-shepherd

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -34,9 +34,6 @@ The preferred method for reviewing tests is on Github. The general
 workflow for test reviews and approval follows the GitHub
 contribution model and is summarized here: 
 
-* Pre-condition: Those interested in reviewing and/or approving
-W3C's tests will set a "Watch" at GitHub so they will be notified 
-when a Pull Request (PR) is made.
 * To initiate a review, make a Pull Request to the main 
 ```web-platform-tests/master``` or ```csswg-test/master``` on 
 GitHub. This will notify all subscribers of the PR, including 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -20,7 +20,9 @@ Below is a list of the original documentation as it was incorporated into this s
 - [Reftest Tutorial][reftest-tutorial]
   - TODO    
 - [Review Process][review]
-  - TODO
+  - [http://wiki.csswg.org/test/review][csswg-wiki-review]
+- [Review Checklist][review-checklist]
+  - [http://wiki.csswg.org/test/review][csswg-wiki-review]
 - [Submission Process][submission]
   - TODO   
 - [testharness.js Documentation][testharness-doc]
@@ -44,6 +46,8 @@ Below is a list of the original documentation as it was incorporated into this s
 [reftest-doc]: ./reftests.html
 [reftest-tutorial]: ./reftest-main-tutorial.html
 [review]: ./review-process.html
+[review-checklist]: ./review-checklist.html
+[csswg-wiki-review]: http://wiki.csswg.org/test/review
 [submission]: ./submission-process.html]
 [testharness-doc]: ./testharness-documentation.html
 [testharness-tutorial]: ./testharness-tutorial.html

--- a/docs/test-templates.md
+++ b/docs/test-templates.md
@@ -168,7 +168,7 @@ or
 ```
 
   The title appears in the generated index, so make sure it is 
-  concise, unique and descriptive. The role of the title is to 
+  concise and descriptive. The role of the title is to 
   identify what specific detail of a feature or combination of 
   features is being tested, so that someone looking through an index 
   can see quickly what's tested in which file. In most cases, this 


### PR DESCRIPTION
- Added the Test Review Policy, including a clarification on same-company reviews
- Added reference to the Shepherd workflow - keeping that document separate on the CSSWG wiki
- Removed suggestion to ask for a review on a mailing list - replaced with info on PR notification behavior
- Added small test review checklist for reviewers' convenience only - ported from the CSSWG wiki (just a small subset of theirs)
- Minor change- <title> tag does not need to be unique
