### PR TITLE
remove Grant of License

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@ layout: legacy
      <li><a href="http://slidesha.re/11mSzQC">testharness.js テストの書き方 (JP)</a></li>   
     <li><a href="http://goo.gl/qoH7s">How to File a Good Bug Report</a></li>
     <li><a href="/resources/github_test_submission.html">Test Submission</a></li>
-    <li><a href="http://www.w3.org/2002/09/wbs/1/testgrants2-200409">W3C Grant of License Questionnaire</a></li>
     <li><a href="http://www.w3.org/Help/Account/Request/Public">W3C Public Account Request Form</a></li>
     <li><a href="http://test.csswg.org/shepherd/">CSS Test Suite Manager "Shepherd"</a></li>
     <ul>


### PR DESCRIPTION
I think this can be removed when https://github.com/w3c/web-platform-tests/pull/261 and https://github.com/w3c/csswg-test/pull/65 are merged
