### PR TITLE
Replacing <a name=xxx> ToC anchors by empty spans.

### DIFF
--- a/docs/github-101.md
+++ b/docs/github-101.md
@@ -95,7 +95,7 @@ will enable you to [submit][submit] your tests using a pull request (more on thi
     browse them on [github.com][github] and see the full history of contributions
     there.
 
-<a name="upstream"></a>
+<span id="upstream" class="toc"></span>
 ## Configure Remote / Upstream
 Synchronizing your forked repository with the W3C repository will enable you to 
 keep your forked local copy up-to-date with the latest commits in the W3C 
@@ -287,7 +287,7 @@ finally accepted. Don't worry about this; it's totally normal. The goal of test
 review is to work together to create the best possible set of tests for the web
 platform.
 
-<a name="praccepted"></a>
+<span id="praccepted" class="toc"></span>
 ## When Pull Request is Accepted
 Once your pull request has been accepted, you will be notified in the GitHub 
 UI and you may get an email.  At this point, your changes have been merged 

--- a/docs/reftests.md
+++ b/docs/reftests.md
@@ -19,7 +19,7 @@ title: Reftest Documentation
   - [CSS Example](#css)
   - [SVG Example](#svg)
 
-<a name="definition">
+<span id="definition" class="toc"></span>
 ## Definition
 
 A reftest is a test that compares the visual output of one file 
@@ -27,7 +27,7 @@ A reftest is a test that compares the visual output of one file
 references). Reftests can be scripted to run and report results 
 automatically, for example, using WebDriver. 
 
-<a name="when-to-write">
+<span id="when-to-write" class="toc"></span>
 ## When to Write Reftests
 
 Writing automated tests using [testharness.js][testharness] is great 
@@ -50,7 +50,7 @@ Here are some scenarios where you'd want to use a reftest for HTML:
 * Does the `type` attribute of an ordered list's `li` element really 
   change the numbering system used to label that `li` element?
 
-<a name="how-to-run">
+<span id="how-to-run" class="toc"></span>
 ## How to Run Reftests
 
 Reftests can be run manually simply by opening the test and the
@@ -68,12 +68,12 @@ also gives the most reliable results. Test failures with small
 mismatches of just a few pixels are sometimes not detectable by the 
 human eye, whereas automated image comparison is precise.
 
-<a name="components">
+<span id="components" class="toc"></span>
 ## Components of a Reftest
 
 A reftest has three parts:
 
-<a name="testfile">
+<span id="testfile" class="toc"></span>
 ### 1. The Reftest Test File ###
 
   The test file uses the technology to be tested. This file should follow the [format][format] and [style][style] guidelines.
@@ -94,7 +94,7 @@ A reftest has three parts:
   taking a screenshot.  If reftest-wait is present, the screenshot 
   can be delayed until the attribute is removed.
 
-<a name="reffile">
+<span id="reffile" class="toc"></span>
 ### 2. The Reftest Reference File ###
   
   This is a different, usually simpler file that results in the 
@@ -139,7 +139,7 @@ A reftest has three parts:
   the same reference, that reference could be named 
   `list-style-type-003-ref.xht`.
 
-<a name="comparison">
+<span id="comparison" class="toc"></span>
 ### 3. The Reftest Comparison ###
 
 In order to designate which files are to be compared to the test 
@@ -166,7 +166,7 @@ Basic example:
 Reference link metadata as described in detail 
 [here][reference-links].
 
-<a name="limitations">
+<span id="limitations" class="toc"></span>
 ## Limitations
 
 In some cases, a test cannot be a reftest. For example, there is no 
@@ -177,14 +177,14 @@ element works, it's possible to construct a reftest for underlining
 a block element, by constructing a reference using underlines on a 
 ```<span>``` that wraps all the content inside the block.
 
-<a name="examples">
+<span id="examples" class="toc"></span>
 ## Example Reftests
 
 These examples are all [self-describing][self-desc] tests as they 
 each have a simple statement on the page describing how it should 
 render to pass the tests.
 
-<a name="html">
+<span id="html" class="toc"></span>
 ### HTML example 
 
 ### Test File 
@@ -290,7 +290,7 @@ Here, for example, the margins, padding, and font-size of the
 ```<bdo>``` and ```<p>``` elements need to be identical.
 
 
-<a name="css">
+<span id="css" class="toc"></span>
 ### CSS Example 
 
 ### Test File 
@@ -366,7 +366,7 @@ and ```background-color: green```.
 </html>
 ```
 
-<a name="svg">
+<span id="svg" class="toc"></span>
 
 ### SVG Example 
 

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -3,7 +3,7 @@ layout: default
 title: Test Review and Approval Process
 ---
 
-<a name="review-policy">
+<span id="review-policy" class="toc"></span>
 
 # Test Review Policy
 
@@ -26,7 +26,7 @@ with an understanding of the [format][format] and [style][style] guidelines
 *To assist with test reviews, a [review checklist][review-checklist]*
 *is available.*
 
-<a name="github-process">
+<span id="github-process" class="toc"></span>
 
 # Test Review and Approval Process on Github
 

--- a/docs/test-format-guidelines.md
+++ b/docs/test-format-guidelines.md
@@ -20,7 +20,7 @@ and [script tests][testharness-documentation]. The design
 requirements are explained and to make things easier we've also 
 provided several [templates][test-templates] you can copy.
 
-<a name="test-type">
+<span id="test-type" class="toc"></span>
 ## Choosing the Test Type
 
 For tests that do not require a page rendering
@@ -34,7 +34,7 @@ It is preferrable that reftests to also be self-describing or
 otherwise easy for humans to interpret, but this is not a 
 requirement.
 
-<a name="design-requirements">
+<span id="design-requirements" class="toc"></span>
 ## Design Requirements
 
 The following are requested of all tests submitted to the W3C.
@@ -67,7 +67,7 @@ Exception: testing for support of red) Since green-with-no-red is
 often used to indicate success, it's best to also avoid green unless 
 using the presence of red to indicate failures.
 
-<a name="acceptable-test-formats">
+<span id="acceptable-test-formats" class="toc"></span>
 ## Acceptable Test Formats
 
 The preferred submission format for tests is either XHTML or 
@@ -105,7 +105,7 @@ When using any characters beyond the ASCII set, in any encoding, the
 character encoding must be specified properly per the specification 
 of the source format.
 
-<a name="file-name-format">
+<span id="file-name-format" class="toc"></span>
 ## File name format
 
 The file name format is ```test-topic-###.ext``` where ```test-
@@ -176,7 +176,7 @@ combo flag.
 The file extension or format of the file, usually ```.xht``` for 
 test files.
 
-<a name="support-files">
+<span id="support-files" class="toc"></span>
 ## Support files
 
 A number of standard images are provided in the support directory. 
@@ -198,7 +198,7 @@ tests within a series). If possible tests should not rely on
 transparency in images, as they are converted to JPEG (which does 
 not support transparency) for the xhtml1print version.
 
-<a name="user-style-sheets">
+<span id="user-style-sheets" class="toc"></span>
 ## User style sheets
 
 Some test may require special user style sheets to be applied in 
@@ -288,7 +288,7 @@ Please flag test that require user style sheets with the userstyle
 flag so people running the tests know that a user style sheet is 
 required.
 
-<a name="http-headers">
+<span id="http-headers" class="toc"></span>
 ## HTTP headers
 
 Some tests may require special HTTP headers. These should be 

--- a/docs/test-style-guidelines.md
+++ b/docs/test-style-guidelines.md
@@ -22,7 +22,7 @@ title: Test Style Guidelines
   - [Overlapping](#overlapping)
 - [Test to Avoid](#avoid)
 
-<a name="key-aspects">
+<span id="key-aspects" class="toc"></span>
 
 ## Key Aspects of a Well Designed Test
 
@@ -36,7 +36,7 @@ tests should meet the following criteria:
 * **The test fails when it's supposed to fail**
 * **It's testing what it claims to be testing**
 
-<a name="self-describing">
+<span id="self-describing" class="toc"></span>
 
 ## Self-Describing Tests
 
@@ -65,7 +65,7 @@ Self-describing tests have some advantages:
 * Failures can (should) be easily determined by a human viewing the 
   test without needing special tools.
 
-<a name="manual-tests">
+<span id="manual-tests" class="toc"></span>
 
 ### Manual Tests
 While it is highly encouraged to write automatable tests either as [
@@ -80,7 +80,7 @@ self-describing tests. Additionally, manual tests should be:
   on even the most modest of screens, unless the test is 
   specifically for scrolling or paginating behaviour.
 
-<a name="reftests">
+<span id="reftests" class="toc"></span>
 
 ### Reftests 
 
@@ -89,7 +89,7 @@ possible. This means the the descriptive statement included in the
 test file must also appear in the reference file so their renderings 
 may be automatically compared.  
 
-<a name="script-tests">
+<span id="script-tests" class="toc"></span>
 
 ### Script Tests 
 
@@ -98,7 +98,7 @@ than including a supplemental statement on the page, this is
 generally done in the test results output from ```testharness.js``` 
 rendered if ```<div id="log"></div>``` is present in the test file.
 
-<a name="sd-examples">
+<span id="sd-examples" class="toc"></span>
 
 ### Self-Describing Test Examples
 
@@ -114,7 +114,7 @@ common [techniques](#techniques) to identify passes:
 * [Imprecise Description 1][imprecise-1]
 * [Imprecise Description 2][imprecise-2]
 
-<a name="techniques">
+<span id="techniques" class="toc"></span>
 
 ## Techniques
 
@@ -124,7 +124,7 @@ clarity and robustness to tests. Particularly for reftests, which
 rely wholly on how the page is rendered, the following should be 
 considered and utilized when designing new tests.
 
-<a name="success">
+<span id="success" class="toc"></span>
 
 ### Indicating success
 
@@ -210,7 +210,7 @@ under test and the features used to make the reference rendering.)
 
 [Text-only Example][identical-text]
 
-<a name="failure">
+<span id="failure" class="toc"></span>
 
 ### Indicating failure
 
@@ -252,7 +252,7 @@ appears anywhere, something must have gone wrong.
 
 _View the page's source to see the usage of the word FAIL._ 
 
-<a name="fonts">
+<span id="fonts" class="toc"></span>
 
 ### Special Fonts
 
@@ -338,7 +338,7 @@ _View the page's source to see how the Ahem font is used._
 2. Open the folder where you downloaded the font file.
 3. Right-click the downloaded font file and select “Install”.
 
-<a name="explanatory">
+<span id="explanatory" class="toc"></span>
 
 ### Explanatory Text
 
@@ -349,7 +349,7 @@ reading the filler text. Good text for use in these situations is,
 quite simply, "This is filler text. This is filler text. This is 
 filler text.". If it looks boring, it's working!
 
-<a name="color">
+<span id="color" class="toc"></span>
 ### Color
 
 In general, using colors in a consistent manner is recommended. 
@@ -382,7 +382,7 @@ for engineers.
 
 Sometimes used for filler text to indicate that it is irrelevant.
 
-<a name="methodical">
+<span id="methodical" class="toc"></span>
 
 ### Methodical testing
 
@@ -402,7 +402,7 @@ short values:
 
 http://www.hixie.ch/tests/adhoc/css/selectors/not/010.xml
 
-<a name="overlapping">
+<span id="overlapping" class="toc"></span>
 ### Overlapping
 
 This technique should not be cast aside as a curiosity -- it is in 
@@ -418,7 +418,7 @@ positioning.
 This idea can be extended to any kind of overlapping, for example 
 overlapping to lines of identical text of different colors.
 
-<a name="avoid">
+<span id="avoid" class="toc"></span>
 
 ## Tests to avoid
 

--- a/docs/test-templates.md
+++ b/docs/test-templates.md
@@ -38,7 +38,7 @@ for your test and save it to a ```.html``` file. See the [template
 details](#template-details) at the bottom of this page for a full 
 description of each template item.
 
-<a name="reftest-template">
+<span id="reftest-template" class="toc"></span>
 ## Reftest Templates
 
 A [reftest][reftest] is composed of at least two files - the Test 
@@ -46,7 +46,7 @@ Case and the Reference. Below are templates for each file. Note that
 the Reference template is less specific (i.e., does not include spec 
 links or assertions) as it is often shared among many tests.
 
-<a name="reftest-test-template">
+<span id="reftest-test-template" class="toc"></span>
 ### Reftest Test Case Template:
 
 ``` html
@@ -69,7 +69,7 @@ links or assertions) as it is often shared among many tests.
 </body>
 ```
 
-<a name="reftest-ref-template">
+<span id="reftest-ref-template" class="toc"></span>
 ### Reftest Reference Template:
 
 ``` html
@@ -85,13 +85,13 @@ links or assertions) as it is often shared among many tests.
     [Content of test]
 </body>
 ```
-<a name="scripttest-template">
+<span id="scripttest-template" class="toc"></span>
 ## Script Test Templates
 
 For script tests, there are two ways to include metadata, so 
 templates for each way are as follows.
 
-<a name="script-test-shared-metadata">
+<span id="script-test-shared-metadata" class="toc"></span>
 ### Script test template: Shared Metadata
 
 Use this template all of your test functions pertain to the same 
@@ -119,7 +119,7 @@ test(function() {
 
 </script>
 ```
-<a name="script-test-pertest-metadata">
+<span id="script-test-pertest-metadata" class="toc"></span>
 
 ### Script test template: Per-Test Metadata
 Use this template all of your test functions pertain to the same 
@@ -153,11 +153,11 @@ test(function () {
 </script>
 ```
 
-<a name="template-details">
+<span id="template-details" class="toc"></span>
 
 ## Template Details
 
-<a name="title-element">
+<span id="title-element" class="toc"></span>
 ### Title element
 
 ``` html
@@ -198,7 +198,7 @@ module name somewhere before the colon, like "CSS Selectors Test:"
 or "CSS Test (Selectors):". Do not include the module version 
 number, since the test might get reused for the next version.
 
-<a name="credits">
+<span id="credits" class="toc"></span>
 ### Credits
 
 ``` html
@@ -231,7 +231,7 @@ Example 3:
 <link rel="author" title="Microsoft" href="http://microsoft.com/" />
 ```
 
-<a name="reviewer">
+<span id="reviewer" class="toc"></span>
 ### Reviewer
 
 ``` html
@@ -283,7 +283,7 @@ This test was written by Bert Bos, then reviewed by Boris Zbarsky,
 who made some corrections before deeming it acceptable. Those 
 corrections were then reviewed and accepted by Bert Bos.
 
-<a name="specification-links">
+<span id="specification-links" class="toc"></span>
 ### Specification Links
 
 Specification Links
@@ -326,7 +326,7 @@ Example 2:
   background-properties" />
 ```
 
-<a name="reference-links">
+<span id="reference-links" class="toc"></span>
 ### Reference Links
 
 *Reftests only*
@@ -379,7 +379,7 @@ Example 2:
 <link rel="mismatch" href="red-box-notref.xht" />
 ```
 
-<a name="requirement-flags">
+<span id="requirement-flags" class="toc"></span>
 ### Requirement Flags
 
 <table>
@@ -516,7 +516,7 @@ Example 3 (no tokens apply):
 <meta name="flags" content="" />
 ```
 
-<a name="test-assertions">
+<span id="test-assertions" class="toc"></span>
 ### Test Assertions
 
 ``` html
@@ -556,10 +556,10 @@ Examples of good test assertions:
   of a block container if that line is also the first formatted line 
   of an element."
 
-<a name="including-scripts">
+<span id="including-scripts" class="toc"></span>
 ### Including Scripts
 
-<a name="embedded-scripts">
+<span id="embedded-scripts" class="toc"></span>
 #### Embedded Scripts:  The ```<script>``` element
 
 ``` html
@@ -575,7 +575,7 @@ Although ```type="application/javascript"``` and
 ```type="application/ecmascript"``` are recommended by [RFC4329][5], 
 the CSS 2.1 test suite  only accepts ```type="text/javascript"```.
 
-<a name="external-scripts">
+<span id="external-scripts" class="toc"></span>
 #### External Scripts
 
 You may include external scripts in your test file as you normally 
@@ -584,7 +584,7 @@ would in any HTML file:
 ```html
 <script src="[path to external script]"></script>
 ```
-<a name="testharness-scripts">
+<span id="testharness-scripts" class="toc"></span>
 #### testharness.js scripts
 
 *Script tests only*
@@ -607,11 +607,11 @@ use them, see the [test harness documentation]
 [testharness-documentation] and the 
 [test harness tutorial][testharness-tutorial]
 
-<a name="including-styles">
+<span id="including-styles" class="toc"></span>
 
 ### Including Styles
 
-<a name="embedded-styles">
+<span id="embedded-styles" class="toc"></span>
 
 #### Embedded Styles: The ```<style>``` element
 
@@ -629,7 +629,7 @@ When creating styles primarily use ID or Class selectors. Inline
 styles should not be used unless the case is specifically testing 
 this scenario.
 
-<a name="external-styles">
+<span id="external-styles" class="toc"></span>
 #### External Styles
 
 You may also include external styles. For example, if many tests in
@@ -640,7 +640,7 @@ share the same stylesheet:
 <link rel="stylesheet" href="[path to external stylesheet]">
 ```
 
-<a name="testharness-css">
+<span id="testharness-css" class="toc"></span>
 #### testharness.css
 
 *Script tests only*
@@ -652,7 +652,7 @@ Just as the paths to the [testharness scripts](#testharness-scripts),
 <link rel="stylesheet" href="/resources/testharness.css">
 ```
 
-<a name="body-content">
+<span id="body-content" class="toc"></span>
 ### "body" Content
 
 ``` html
@@ -683,7 +683,7 @@ Just as the paths to the [testharness scripts](#testharness-scripts),
 * Guidelines on designing the content of the test can be found in 
   the [CSS2.1 Test Case Authoring Guidelines][7].
 
-<a name="log-div">
+<span id="log-div" class="toc"></span>
 ### "log" div
 
 *Script tests only*


### PR DESCRIPTION
Fixes an issue which crops up when anchors are accidentally left open.
