### PR TITLE
tokyo meetup: add another expert/speaker

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -594,6 +594,10 @@ people: [
       "pic": "/assets/experts/yongwoo_jeon.png"
   },
   {
+      "name": "Yuki Sekiguchi",
+      "about": "ACCESS",
+  },
+  {
       "name": "Vincent Hardy",
       "about": "Adobe, SVG Working Group",
       "pic": "/assets/experts/vincent_hardy.png"

--- a/events/2014/tokyo.html
+++ b/events/2014/tokyo.html
@@ -5,8 +5,8 @@ date: April 12<sup>th</sup>, 2014
 registration_link: http://html5j-testing.doorkeeper.jp/events/10161
 title: Test the Web Forward Meetup Tokyo #2
 sponsors: ["ACCESS", "Adobe", "Google", "KDDI", "NTT Communications"]
-speakers: ["Gérard Talbot", "Masataka Yakura"]
-experts: ["Gérard Talbot", "Koji Ishii", "Kensaku Komatsu", "Masataka Yakura"]
+speakers: ["Yuki Sekiguchi", "Gérard Talbot", "Masataka Yakura"]
+experts: ["Koji Ishii", "Kensaku Komatsu", "Yuki Sekiguchi", "Gérard Talbot", "Masataka Yakura"]
 schedule:
     default:
         Agenda:


### PR DESCRIPTION
We've got another expert/speaker from ACCESS. He's been hacking WebKit/Chromium and has insight for text layout stuffs (ruby, text-decoration, etc.)
