### PR TITLE
Correct spelling: underlining->underlying in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 
       </div>
 
-      <p class=lead>As the Web morphed from a document exchange system to the World's most advanced application delivery platform, the requirements on the underlining technologies and the browsers implementing them changed dramatically. Web applications built today need a robust and interoperable Web that only thorough browser testing can guarantee.
+      <p class=lead>As the Web morphed from a document exchange system to the World's most advanced application delivery platform, the requirements on the underlying technologies and the browsers implementing them changed dramatically. Web applications built today need a robust and interoperable Web that only thorough browser testing can guarantee.
       </p>
       <p class=lead>To meet this new challenge, W3C is launching an unprecedented effort to rethink and scale up its testing offering.</p>
 


### PR DESCRIPTION
I think this is probably the intended word.